### PR TITLE
Simulate ska namespace package hack

### DIFF
--- a/native/pkg_a/example_pkg_a/__init__.py
+++ b/native/pkg_a/example_pkg_a/__init__.py
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 name = 'a'
+different = 1

--- a/native/pkg_a/setup.py
+++ b/native/pkg_a/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 setup(
     name='example_pkg_a',
 
-    version='1',
+    version='1.3',
 
     description='',
     long_description='',
@@ -28,6 +28,7 @@ setup(
 
     license='Apache Software License',
 
-    packages=['example_pkg.a'],
+    packages=['example_pkg_a', 'example_pkg.a'],
+    package_dir={'example_pkg.a': 'example_pkg_a', 'example_pkg_a': 'example_pkg_a'},
     zip_safe=False,
 )


### PR DESCRIPTION
This seems to work OK.
```
conda create -n pip-namespace python=3.10
conda activate pip-namespace
cd native/pkg_a
pip install . --verbose
cd ../pkg_b
pip install . --verbose
# Confirm that example_pkg_a, example_pkg.a, example_pkg.b are all importable
cd ../pkg_a
# <update version in setup.py>
pip install . --verbose
# In ska (e.g. chandra_maneuver and chandra_time) the above step blows away the Chandra/  directory
# but in this example it does not.
# Confirm that example_pkg_a, example_pkg.a, example_pkg.b are all importable
```

But if the package is installed with `python setup.py install ...` then uninstalling fails by removing the entire namespace directory.
```
(pip-namespace) ➜  pkg_a git:(ska-namespace) python setup.py install --single-version-externally-managed --record=record.txt
running install
/Users/aldcroft/miniconda3/envs/pip-namespace/lib/python3.10/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
running build
running build_py
running install_lib
creating /Users/aldcroft/miniconda3/envs/pip-namespace/lib/python3.10/site-packages/example_pkg_a
copying build/lib/example_pkg_a/__init__.py -> /Users/aldcroft/miniconda3/envs/pip-namespace/lib/python3.10/site-packages/example_pkg_a
creating /Users/aldcroft/miniconda3/envs/pip-namespace/lib/python3.10/site-packages/example_pkg/a
copying build/lib/example_pkg/a/__init__.py -> /Users/aldcroft/miniconda3/envs/pip-namespace/lib/python3.10/site-packages/example_pkg/a
byte-compiling /Users/aldcroft/miniconda3/envs/pip-namespace/lib/python3.10/site-packages/example_pkg_a/__init__.py to __init__.cpython-310.pyc
byte-compiling /Users/aldcroft/miniconda3/envs/pip-namespace/lib/python3.10/site-packages/example_pkg/a/__init__.py to __init__.cpython-310.pyc
running install_egg_info
running egg_info
writing example_pkg_a.egg-info/PKG-INFO
writing dependency_links to example_pkg_a.egg-info/dependency_links.txt
writing top-level names to example_pkg_a.egg-info/top_level.txt
reading manifest file 'example_pkg_a.egg-info/SOURCES.txt'
writing manifest file 'example_pkg_a.egg-info/SOURCES.txt'
Copying example_pkg_a.egg-info to /Users/aldcroft/miniconda3/envs/pip-namespace/lib/python3.10/site-packages/example_pkg_a-1.3-py3.10.egg-info
running install_scripts
writing list of installed files to 'record.txt'
(pip-namespace) ➜  pkg_a git:(ska-namespace) pip uninstall --verbose example_pkg_a                                          
Found existing installation: example-pkg-a 1.3
Uninstalling example-pkg-a-1.3:
  Would remove:
    /Users/aldcroft/miniconda3/envs/pip-namespace/lib/python3.10/site-packages/example_pkg
    /Users/aldcroft/miniconda3/envs/pip-namespace/lib/python3.10/site-packages/example_pkg_a
    /Users/aldcroft/miniconda3/envs/pip-namespace/lib/python3.10/site-packages/example_pkg_a-1.3-py3.10.egg-info
  Will actually move:
    /Users/aldcroft/miniconda3/envs/pip-namespace/lib/python3.10/site-packages/example_pkg
    /Users/aldcroft/miniconda3/envs/pip-namespace/lib/python3.10/site-packages/example_pkg_a
    /Users/aldcroft/miniconda3/envs/pip-namespace/lib/python3.10/site-packages/example_pkg_a-1.3-py3.10.egg-info
Proceed (Y/n)? n
(pip-namespace) ➜  pkg_a git:(ska-namespace) 
```

